### PR TITLE
Use context manager to close ThreadPool

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -57,7 +57,8 @@ class MycroftSkillsManager(object):
                 LOG.exception('Error running {} on {}:'.format(
                     func.__name__, skill.name
                 ))
-        return all(ThreadPool(100).map(run_item, skills))
+        with ThreadPool(100) as tp:
+            return all(tp.map(run_item, skills))
 
     def install_defaults(self):
         """Installs the default skills, updates all others"""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.5.6',
+    version='0.5.7',
     packages=['msm'],
     install_requires=['GitPython', 'typing'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',


### PR DESCRIPTION
On Pi the threads limit seems to be somewhere between 200 and 256, since the ThreadPool isn't closed these seem to hang around and cause RuntimeErrors when not enough threads can be spawned.

Using the context manager will close these explicityly (or at least implicitly (the point is that they get closed. Good)).