### PR TITLE
Make non-ff updates work for "unsafe branches"

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -226,7 +226,7 @@ class SkillEntry(object):
 
             git.fetch()
             current_branch = git.rev_parse('--abbrev-ref', 'HEAD').strip()
-            if current_branch in SWITCHABLE_BRANCHES:
+            if self.sha and current_branch in SWITCHABLE_BRANCHES:
                 # Check out correct branch
                 git.checkout(self._find_sha_branch())
 

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -20,9 +20,9 @@ from msm.exceptions import PipRequirementsException, \
 
 LOG = logging.getLogger(__name__)
 
-# Branches which can be updated from despite non-fastforward
+# Branches which can be switched from when updating
 # TODO Make this configurable
-UNSAFE_BRANCHES = ['master']
+SWITCHABLE_BRANCHES = ['master']
 
 
 class SkillEntry(object):
@@ -226,7 +226,7 @@ class SkillEntry(object):
 
             git.fetch()
             current_branch = git.rev_parse('--abbrev-ref', 'HEAD').strip()
-            if current_branch in UNSAFE_BRANCHES:
+            if current_branch in SWITCHABLE_BRANCHES:
                 # Check out correct branch
                 git.checkout(self._find_sha_branch())
 


### PR DESCRIPTION
Unsafe branches are currently only "master"

The method is:
- find branch of sha
- checkout that branch
- reset to a point where the merge will work even if the head of the current branch is ahead of the sha
- perform merge as normal