### PR TITLE
Remove '->' references from branch when getting branch with SHA

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -236,9 +236,10 @@ class SkillEntry(object):
 
     def _find_sha_branch(self):
         git = Git(self.path)
-        sha_branch = git.branch(
+        sha_branches = git.branch(
             contains=self.sha, all=True
-        ).split('\n')[0]
+        ).split('\n')
+        sha_branch = [b for b in sha_branches if ' -> ' not in b][0]
         sha_branch = sha_branch.strip('* \n').replace('remotes/', '')
         for remote in git.remote().split('\n'):
             sha_branch = sha_branch.replace(remote + '/', '')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.5.12',
+    version='0.5.13',
     packages=['msm'],
     install_requires=['GitPython', 'typing'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',


### PR DESCRIPTION
I think this is a good approach, a -> should generally have a matching branch and can thus safely be removed from the list.