### PR TITLE
 Handle the new default skill listings

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -117,9 +117,8 @@ class MycroftSkillsManager(object):
 
         if self.platform not in skill_groups:
             LOG.error('Unknown platform:' + self.platform)
-        return chain(*[
-            skill_groups.get(i, []) for i in {'default', self.platform}
-        ])
+        return skill_groups.get(self.platform,
+                                skill_groups.get('default', []))
 
     def list(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.5.17',
+    version='0.5.18',
     packages=['msm'],
     install_requires=['GitPython', 'typing'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',


### PR DESCRIPTION
mycroft-skills has started to list all skills for each platform in all
the default files. To avoid that many of the skills are handled twice
during msm default, the automatic inclusion of the default platform is
removed.

A simple test showing the issue:
```python
from msm import MycroftSkillsManager

msm = MycroftSkillsManager(platform='mycroft_mark_1')
print(len(list(msm.list_defaults())))
```

will print 55 currently and after the PR should show the correct 27.