### PR TITLE
Add handling of the skills.json file 

### DIFF
--- a/msm/__main__.py
+++ b/msm/__main__.py
@@ -129,7 +129,7 @@ def main(args=None, printer=print):
             printer('{}: {}'.format(exc_type, str(e)))
             return get_error_code(e.__class__)
         finally:
-            msm.write_skills_data(msm.skills_data)
+            msm.write_skills_data()
 
 if __name__ == "__main__":
     main()

--- a/msm/__main__.py
+++ b/msm/__main__.py
@@ -98,7 +98,7 @@ def main(args=None, printer=print):
     )
     main_functions = {
         'install': lambda: msm.install(args.skill, args.author,
-                                       args.constraints),
+                                       args.constraints, 'cli'),
         'remove': lambda: msm.remove(args.skill, args.author),
         'list': lambda: '\n'.join(
             skill.name + (
@@ -127,7 +127,8 @@ def main(args=None, printer=print):
         exc_type = e.__class__.__name__
         printer('{}: {}'.format(exc_type, str(e)))
         return get_error_code(e.__class__)
-
+    finally:
+        msm.write_skills_data(msm.skills_data)
 
 if __name__ == "__main__":
     main()

--- a/msm/__main__.py
+++ b/msm/__main__.py
@@ -116,19 +116,20 @@ def main(args=None, printer=print):
         ),
         'info': lambda: skill_info(msm.find_skill(args.skill, args.author))
     }
-    try:
-        result = main_functions[args.action]()
-        if result is False:
-            return 1
-        if isinstance(result, str):
-            printer(result)
-        return 0
-    except MsmException as e:
-        exc_type = e.__class__.__name__
-        printer('{}: {}'.format(exc_type, str(e)))
-        return get_error_code(e.__class__)
-    finally:
-        msm.write_skills_data(msm.skills_data)
+    with msm.lock:
+        try:
+            result = main_functions[args.action]()
+            if result is False:
+                return 1
+            if isinstance(result, str):
+                printer(result)
+            return 0
+        except MsmException as e:
+            exc_type = e.__class__.__name__
+            printer('{}: {}'.format(exc_type, str(e)))
+            return get_error_code(e.__class__)
+        finally:
+            msm.write_skills_data(msm.skills_data)
 
 if __name__ == "__main__":
     main()

--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -36,11 +36,13 @@ from msm.skill_entry import SkillEntry
 from msm.skill_repo import SkillRepo
 from msm.skills_data import (build_skill_entry, get_skill_entry,
                              write_skills_data, load_skills_data)
+
+from msm.util import MsmProcessLock
+
+
 LOG = logging.getLogger(__name__)
 
 CURRENT_SKILLS_DATA_VERSION = 1
-
-
 
 
 class MycroftSkillsManager(object):
@@ -54,7 +56,10 @@ class MycroftSkillsManager(object):
                           or self.DEFAULT_SKILLS_DIR
         self.repo = repo or SkillRepo()
         self.versioned = versioned
-        self.skills_data = self.load_skills_data()
+        self.lock = MsmProcessLock()
+
+        with self.lock:
+            self.skills_data = self.load_skills_data()
 
     def __upgrade_skills_data(self, skills_data):
         new = {}

--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -71,14 +71,21 @@ class MycroftSkillsManager(object):
             local_skills = [s for s in self.list() if s.is_local]
             default_skills = [s.name for s in self.list_defaults()]
             for skill in local_skills:
-                if skill.name in default_skills:
+                if 'origin' in skills_data.get(skill.name, {}):
+                    origin = skills_data[skill.name]['origin']
+                elif skill.name in default_skills:
                     origin = 'default'
                 elif skill.url:
                     origin = 'cli'
                 else:
                     origin = 'non-msm'
-                beta = skills_data.get(skill, {}).get('beta', False)
+                beta = skills_data.get(skill.name, {}).get('beta', False)
                 entry = build_skill_entry(skill.name, origin, beta)
+                entry['installed'] = \
+                    skills_data.get(skill.name, {}).get('installed') or 0
+                entry['update'] = \
+                    skills_data.get(skill.name, {}).get('updated') or 0
+
                 new['skills'].append(entry)
             new['upgraded'] = True
         return new
@@ -194,7 +201,7 @@ class MycroftSkillsManager(object):
                 skill = self.find_skill(skill, author)
             entry = get_skill_entry(skill.name, self.skills_data)
             if entry:
-                entry['beta'] = True
+                entry['beta'] = skill.is_beta
             if skill.update():
                 # On successful update update the update value
                 if entry:

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -302,8 +302,10 @@ class SkillEntry(object):
             LOG.info('Updated ' + self.name)
             # Trigger reload by modifying the timestamp
             os.utime(join(self.path, '__init__.py'))
+            return True
         else:
             LOG.info('Nothing new for ' + self.name)
+            return False
 
     def remove(self):
         if not self.is_local:

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -73,6 +73,13 @@ class SkillEntry(object):
         self.id = self.extract_repo_id(url) if url else name
         self.is_local = exists(path)
 
+    @property
+    def is_beta(self):
+        return not self.sha or self.sha == 'HEAD'
+
+    def __str__(self):
+        return self.name
+
     def attach(self, remote_entry):
         """Attach a remote entry to a local entry"""
         self.name = remote_entry.name

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -265,11 +265,11 @@ class SkillEntry(object):
 
         LOG.info('Successfully installed ' + self.name)
 
-    def update_deps(self):
+    def update_deps(self, constraints=None):
         if self.msm:
             self.run_skill_requirements()
         self.run_requirements_sh()
-        self.run_pip()
+        self.run_pip(constraints)
 
     def _find_sha_branch(self):
         git = Git(self.path)

--- a/msm/skills_data.py
+++ b/msm/skills_data.py
@@ -9,8 +9,11 @@ def load_skills_data() -> dict:
     """Contains info on how skills should be updated"""
     skills_data_file = expanduser('~/.mycroft/skills.json')
     if isfile(skills_data_file):
-        with open(skills_data_file) as f:
-            return json.load(f)
+        try:
+            with open(skills_data_file) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
     else:
         return {}
 

--- a/msm/skills_data.py
+++ b/msm/skills_data.py
@@ -49,3 +49,7 @@ def build_skill_entry(name, origin, beta) -> dict:
     entry['updated'] = 0
     entry['installation'] = 'installed'
     return entry
+
+
+def skills_data_hash(data):
+    return hash(json.dumps(data, sort_keys=True))

--- a/msm/skills_data.py
+++ b/msm/skills_data.py
@@ -1,0 +1,48 @@
+"""
+    Functions related to manipulating the skills_data.json
+"""
+
+from os.path import expanduser, isfile
+import json
+
+def load_skills_data() -> dict:
+    """Contains info on how skills should be updated"""
+    skills_data_file = expanduser('~/.mycroft/skills.json')
+    if isfile(skills_data_file):
+        with open(skills_data_file) as f:
+            return json.load(f)
+    else:
+        return {}
+
+def write_skills_data(data: dict):
+    skills_data_file = expanduser('~/.mycroft/skills.json')
+    with open(skills_data_file, 'w') as f:
+        json.dump(data, f, indent=4, separators=(',',':'))
+
+def get_skill_entry(name, skills_data) -> dict:
+    """ Find a skill entry in the skills_data and returns it. """
+    for e in skills_data.get('skills', []):
+        if e.get('name') == name:
+            return e
+    return None
+
+
+def build_skill_entry(name, origin, beta) -> dict:
+    """ Create a new skill entry
+    
+    Arguments:
+        name: skill name
+        origin: the source of the installation
+        beta: Boolean indicating wether the skill is in beta
+    Returns:
+        populated skills entry
+    """
+    entry = {}
+    entry['name'] = name
+    entry['origin'] = origin
+    entry['beta'] = beta
+    entry['status'] = 'active'
+    entry['installed'] = 0
+    entry['updated'] = 0
+    entry['installation'] = 'installed'
+    return entry

--- a/msm/util.py
+++ b/msm/util.py
@@ -20,7 +20,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import git
-
+from os.path import exists
+from os import chmod
+from fasteners.process_lock import InterProcessLock
 
 class Git(git.cmd.Git):
     """Prevents asking for password for private repos"""
@@ -32,3 +34,13 @@ class Git(git.cmd.Git):
             env.update(self.env)
             return super(Git, self).__getattr__(item)(*args, env=env, **kwargs)
         return wrapper
+
+
+class MsmProcessLock(InterProcessLock):
+    def __init__(self):
+        lock_path = '/tmp/msm_lock'
+        if not exists(lock_path):
+            lock_file = open(lock_path, '+w')
+            lock_file.close()
+            chmod(lock_path, 0o777)
+        super().__init__(lock_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 GitPython
 typing
+fasteners

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.5.19',
+    version='0.6.0',
     packages=['msm'],
     install_requires=['GitPython', 'typing', 'fasteners'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name='msm',
     version='0.5.19',
     packages=['msm'],
-    install_requires=['GitPython', 'typing'],
+    install_requires=['GitPython', 'typing', 'fasteners'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',
     license='Apache-2.0',
     author='jarbasAI, Matthew Scholefield',


### PR DESCRIPTION
This implements the basic features for syncing the skills.json file with the server no matter the installation source

- Initial upgrade of existing/nonexisting skills.json
- Curating if skills are modified without msm noticing
- Install now takes an origin argument depending on the source of the installation
- Update will update the updated field
- locking of the skills.json file