### PR TITLE
Handle writing automatically

### DIFF
--- a/msm/__main__.py
+++ b/msm/__main__.py
@@ -128,8 +128,6 @@ def main(args=None, printer=print):
             exc_type = e.__class__.__name__
             printer('{}: {}'.format(exc_type, str(e)))
             return get_error_code(e.__class__)
-        finally:
-            msm.write_skills_data()
 
 if __name__ == "__main__":
     main()

--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -51,10 +51,16 @@ def save_skills_data(func):
         will_save = False
         if not self.saving_handled:
             will_save = self.saving_handled = True
-        ret = func(self, *args, **kwargs)
-        if will_save:
-            self.write_skills_data()
-            self.saving_handled = False
+        try:
+            ret = func(self, *args, **kwargs)
+            # Write only if no exception occurs
+            if will_save:
+                self.write_skills_data()
+        finally:
+            # Always restore saving_handled flag
+            if will_save:
+                self.saving_handled = False
+
         return ret
 
     return func_wrapper


### PR DESCRIPTION
Using decorator as suggested by @MatthewScholefield. The decorator sets
an internal attirbute so following calls to a decorated function will
not try to write data.


Apparently I didn't push this commit last week. Lets add it as well to keep the python interface the same.