### PR TITLE
Bugfix/handle git errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.6.2',
+    version='0.6.3',
     packages=['msm'],
     install_requires=['GitPython', 'typing', 'fasteners'],
     url='https://github.com/MycroftAI/mycroft-skills-manager',


### PR DESCRIPTION
 Do not destroy the existing repo on git errors

Connection errors also cause the GitCommandError to be raised in this case it's bad if the skills repo is removed because it won't be recreated and msm won't be able to be created.

This implements a flow:
Try to update

On failure of update try to create a temporary repo to use in /tmp

If this fails try using the existing repo without update