### PR TITLE
Fix skill dependency installation

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -237,9 +237,6 @@ class SkillEntry(object):
         if self.is_local:
             raise AlreadyInstalled(self.name)
 
-        if self.msm:
-            self.run_skill_requirements()
-
         LOG.info("Downloading skill: " + self.url)
         try:
             tmp_location = mktemp()
@@ -255,6 +252,9 @@ class SkillEntry(object):
 
         try:
             move(tmp_location, self.path)
+
+            if self.msm:
+                self.run_skill_requirements()
 
             self.run_requirements_sh()
             self.run_pip(constraints)


### PR DESCRIPTION
Previously the repo wouldn't exist when it would check for skill_requirements.txt