### PR TITLE
Do not restore backup on SkillModified exception

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -81,7 +81,7 @@ def _backup_previous_version(func: Callable=None):
 
         # Modified skill or GitError should not restore working copy
         except (SkillModified, GitError, GitException):
-            pass
+            raise
         except Exception:
             LOG.info('Problem performing action. Restoring skill to '
                      'previous state...')

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -78,6 +78,10 @@ def _backup_previous_version(func: Callable=None):
             shutil.copytree(self.path, self.old_path)
         try:
             func(self, *args, **kwargs)
+
+        # Modified skill or GitError should not restore working copy
+        except (SkillModified, GitError):
+            pass
         except Exception:
             LOG.info('Problem performing action. Restoring skill to '
                      'previous state...')

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -43,7 +43,7 @@ from pako import PakoManager
 from msm import SkillRequirementsException, git_to_msm_exceptions
 from msm.exceptions import PipRequirementsException, \
     SystemRequirementsException, AlreadyInstalled, SkillModified, \
-    AlreadyRemoved, RemoveException, CloneException, NotInstalled
+    AlreadyRemoved, RemoveException, CloneException, NotInstalled, GitException
 from msm.util import Git
 
 LOG = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ def _backup_previous_version(func: Callable=None):
             func(self, *args, **kwargs)
 
         # Modified skill or GitError should not restore working copy
-        except (SkillModified, GitError):
+        except (SkillModified, GitError, GitException):
             pass
         except Exception:
             LOG.info('Problem performing action. Restoring skill to '


### PR DESCRIPTION
When using the latest version and working with skills I get messages like 
>direnv: error LoadConfig() Getwd failed: "getwd: no such file or directory"

Basically meaning that the current directory has been replaced, I also get messages that the file has been changed and my edits might overwrite changes.

I believe these are generated since the skill is overwritten by the backup copy due to it catching the SkillModified exception.

This skips the above exception.