### PR TITLE
Market info

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -109,11 +109,18 @@ class SkillEntry(object):
 
     def __init__(self, name, path, url='', sha='', msm=None):
         url = url.rstrip('/')
+        url = url[:-len('.git')] if url.endswith('.git') else url
         self.name = name
         self.path = path
         self.url = url
         self.sha = sha
         self.msm = msm
+        if msm:
+            u = url.lower()
+            self.meta_info = msm.repo.skills_meta_info.get(u, {})
+        else:
+            self.meta_info = {}
+
         self.author = self.extract_author(url) if url else ''
         self.id = self.extract_repo_id(url) if url else name
         self.is_local = exists(path)

--- a/msm/skill_repo.py
+++ b/msm/skill_repo.py
@@ -30,9 +30,20 @@ from msm import git_to_msm_exceptions
 from msm.exceptions import MsmException
 from msm.util import Git
 import logging
+import requests
 
 LOG = logging.getLogger(__name__)
 
+MYCROFT_SKILLS_DATA = "https://raw.githubusercontent.com/MycroftAI/mycroft-skills-data"
+
+def load_skills_data(branch):
+    try:
+        market_info_url = (MYCROFT_SKILLS_DATA + "/" + branch +
+                           "/skill-metadata.json")
+        info = requests.get(market_info_url).json()
+        return {info[k]['repo'].lower(): info[k] for k in info}
+    except requests.HTTPError:
+        return {}
 
 class SkillRepo(object):
     def __init__(self, path=None, url=None, branch=None):
@@ -40,6 +51,7 @@ class SkillRepo(object):
         self.url = url or "https://github.com/MycroftAI/mycroft-skills"
         self.branch = branch or "19.02"
         self.repo_info = {}
+        self.skills_meta_info = load_skills_data(self.branch)
 
     def read_file(self, filename):
         with open(join(self.path, filename)) as f:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='msm',
-    version='0.7.3',
+    version='0.7.4',
     packages=['msm'],
     install_requires=[
         'GitPython', 'typing', 'fasteners', 'pyyaml', 'pako',


### PR DESCRIPTION
meta_info is now added to the SkillEntry, this will contain the skill's info from the skills-meta.json generated from the skills Readme.

The data used here can also be used to get additional skill info such as the title in the market.