### PR TITLE
Feature/skill gid

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -152,6 +152,20 @@ class SkillEntry(object):
                 current_sha != skill_shas[self.name] or
                 mod)
 
+    @property
+    def skill_gid(self):
+        """ Format skill gid for the skill
+        
+        """
+        gid = ''
+        if self.is_dirty:
+                gid +='@|'
+        if self.meta_info != {}:
+            gid += self.meta_info['skill_gid']
+        else:
+            gid += '{}|{}'.format(self.name, self.msm.repo.branch)
+        return gid
+
     def __str__(self):
         return self.name
 

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -130,6 +130,28 @@ class SkillEntry(object):
     def is_beta(self):
         return not self.sha or self.sha == 'HEAD'
 
+    @property
+    def is_dirty(self):
+        """ True if different from the version in the mycroft-skills repo.
+
+        Considers a skill dirty if
+        - the checkedout sha doesn't match the mycroft-skills repo
+        - the skill doesn't exist in the mycroft-skills repo
+        - the skill is not a git repo
+        - has local modifications
+        """
+        try:
+            checkout = Git(self.path)
+            mod = checkout.status(porcelain=True, untracked_files='no') != ''
+            current_sha = checkout.rev_parse('HEAD')
+        except GitCommandError: # Not a git checkout
+            return True
+
+        skill_shas = {d[0]: d[3] for d in self.msm.repo.get_skill_data()}
+        return (self.name not in skill_shas or
+                current_sha != skill_shas[self.name] or
+                mod)
+
     def __str__(self):
         return self.name
 

--- a/msm/skills_data.py
+++ b/msm/skills_data.py
@@ -33,13 +33,14 @@ def get_skill_entry(name, skills_data) -> dict:
     return {}
 
 
-def build_skill_entry(name, origin, beta) -> dict:
+def build_skill_entry(name, origin, beta, skill_gid) -> dict:
     """ Create a new skill entry
     
     Arguments:
         name: skill name
         origin: the source of the installation
         beta: Boolean indicating wether the skill is in beta
+        skill_gid: skill global id
     Returns:
         populated skills entry
     """
@@ -50,7 +51,8 @@ def build_skill_entry(name, origin, beta) -> dict:
         'status': 'active',
         'installed': 0,
         'updated': 0,
-        'installation': 'installed'
+        'installation': 'installed',
+        'skill_gid': skill_gid
     }
 
 


### PR DESCRIPTION
Add support for skill_gid

Skills are now to be uniquely identifiable with a skill_gid. If the skill exactly matches the one in the skill-repo and is unmodified the `skill-name|branch` should be provided as gid. if it's modified or not in the skills repo it will be marked so by an `@` field (later to be populated by mycroft-core with an uuid).

This adds the skill_gid to the manifest as well bumping the file version to 2.

I'm not 100% sure of the way the "is_dirty" is determined so any insights and suggestions there are welcome.