### PR TITLE
Skill_gid related bugs

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -131,8 +131,11 @@ class MycroftSkillsManager(object):
         local_skill_dict = {s.name: s for s in local_skills}
 
         for s in skills_data['skills']:
-            skill_info = local_skill_dict[s['name']]
-            s['skill_gid'] = skill_info.skill_gid
+            if s['name'] in local_skill_dict:
+                skill_info = local_skill_dict[s['name']]
+                s['skill_gid'] = skill_info.skill_gid
+            else:
+                s['skill_gid'] = ''
         skills_data['version'] = 2
         return skills_data
 

--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -155,7 +155,8 @@ class MycroftSkillsManager(object):
                     origin = 'cli'
                 else:
                     origin = 'non-msm'
-                entry = build_skill_entry(skill.name, origin, False)
+                entry = build_skill_entry(skill.name, origin, False,
+                                          skill.skill_gid)
                 skills_data['skills'].append(entry)
 
         # Check for skills in the list that doesn't exist in the filesystem

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -145,6 +145,8 @@ class SkillEntry(object):
         - the skill is not a git repo
         - has local modifications
         """
+        if not exists(self.path):
+            return False
         try:
             checkout = Git(self.path)
             mod = checkout.status(porcelain=True, untracked_files='no') != ''

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -110,7 +110,6 @@ class SkillEntry(object):
     def __init__(self, name, path, url='', sha='', msm=None):
         url = url.rstrip('/')
         url = url[:-len('.git')] if url.endswith('.git') else url
-        self.name = name
         self.path = path
         self.url = url
         self.sha = sha
@@ -120,9 +119,15 @@ class SkillEntry(object):
             self.meta_info = msm.repo.skills_meta_info.get(u, {})
         else:
             self.meta_info = {}
+        if name is not None:
+            self.name = name
+        elif 'name' in self.meta_info:
+            self.name = self.meta_info['name']
+        else:
+            self.name = basename(path)
 
         self.author = self.extract_author(url) if url else ''
-        self.id = self.extract_repo_id(url) if url else name
+        self.id = self.extract_repo_id(url) if url else self.name
         self.is_local = exists(path)
         self.old_path = None  # Path of previous version while upgrading
 
@@ -155,7 +160,7 @@ class SkillEntry(object):
     @property
     def skill_gid(self):
         """ Format skill gid for the skill
-        
+
         """
         gid = ''
         if self.is_dirty:
@@ -179,7 +184,7 @@ class SkillEntry(object):
 
     @classmethod
     def from_folder(cls, path, msm=None):
-        return cls(basename(path), path, cls.find_git_url(path), msm=msm)
+        return cls(None, path, cls.find_git_url(path), msm=msm)
 
     @classmethod
     def create_path(cls, folder, url, name=''):


### PR DESCRIPTION
- skill_gid would be incorrect when skill entry is generated from get_folder
- upgrade would fail if an entry doesn't exist locally
- is_dirty would throw errors when invoked for non-existing path (during install for example)
- curate_skills_list didn't supply a skill_gid when building skill entry.