### PR TITLE
Fix skill_gid when entry has no meta

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -167,6 +167,13 @@ class MycroftSkillsManager(object):
                 remove_list.append(s)
         for skill in remove_list:
             skills_data['skills'].remove(skill)
+
+        # Update skill gids
+        for s in local_skills:
+            for e in skills_data['skills']:
+                if e['name'] == s.name:
+                    e['skill_gid'] = s.skill_gid
+
         return skills_data
 
     def load_skills_data(self) -> dict:

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -161,17 +161,15 @@ class SkillEntry(object):
 
     @property
     def skill_gid(self):
-        """ Format skill gid for the skill
-
-        """
+        """ Format skill gid for the skill. """
         gid = ''
         if self.is_dirty:
-                gid +='@|'
+            gid += '@|'
         if self.meta_info != {}:
             gid += self.meta_info['skill_gid']
         else:
             name = self.name.split('.')[0]
-            gid += '{}|{}'.format(name, self.msm.repo.branch)
+            gid += name
         return gid
 
     def __str__(self):


### PR DESCRIPTION
The entry doesn't show the branch anymore if it's not in the marketplace.

Basically:
Skill is the exact version as the one in the marketplace -> `skill-name|branch`
Skill is not the version as in the marketplace or modified -> `@|skill-name|branch`
Skill is not in the marketplace -> `@|skill-name`

