### PR TITLE
Fix missing member all_skills for "default" action

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -491,7 +491,7 @@ class MycroftSkillsManager(object):
         invalidates the cache.
         """
         LOG.info('invalidating skills cache')
-        if hasattr(self, '_cache'):
+        if hasattr(self, '_cache') and 'all_skills' in self._cache:
             del self._cache['all_skills']
         self._all_skills = None if new_value is None else new_value
         self._local_skills = None


### PR DESCRIPTION
When running default many install happens in parallell resulting in
multiple deletes of the chache.

This adds a simple check to avoid this.

I'm haven't done more research on how this could affect installations but as checks goes this is a simple and feels good to have.