### PR TITLE
Remove typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 GitPython
-typing
 fasteners
 lazy

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,10 @@ setup(
     version='0.8.3',
     packages=['msm'],
     install_requires=[
-        'GitPython', 'typing', 'fasteners', 'pyyaml', 'pako',
+        'GitPython', 'fasteners', 'pyyaml', 'pako',
         'lazy'
     ],
+    python_requires='>=3.5',
     url='https://github.com/MycroftAI/mycroft-skills-manager',
     license='Apache-2.0',
     author='jarbasAI, Matthew Scholefield',

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,9 @@ setup(
     python_requires='>=3.5',
     url='https://github.com/MycroftAI/mycroft-skills-manager',
     license='Apache-2.0',
-    author='jarbasAI, Matthew Scholefield',
-    author_email='jarbasai@mailfence.com, matthew331199@gmail.com',
+    author='jarbasAI, Matthew Scholefield, Mycroft AI',
+    author_email='jarbasai@mailfence.com, matthew331199@gmail.com, '
+                 'dev@mycroft.ai',
     description='Mycroft Skills Manager',
     entry_points={
         'console_scripts': {


### PR DESCRIPTION
Typing is not required for Python 3.5, since Python 3.4 is deprecated typing can be removed.

This also adds Mycroft AI as an author.