### PR TITLE
Make sure install raises exception on failure

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -411,6 +411,7 @@ class MycroftSkillsManager(object):
             skill.remove()
         except AlreadyRemoved:
             LOG.info('Skill {} has already been removed'.format(skill.name))
+            raise
         except RemoveException:
             LOG.exception('Failed to remove skill ' + skill.name)
             raise

--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -71,10 +71,9 @@ def save_device_skill_state(func):
             will_save = self.saving_handled = True
         try:
             ret = func(self, *args, **kwargs)
-            # Write only if no exception occurs
+        finally:
             if will_save:
                 self.write_device_skill_state()
-        finally:
             # Always restore saving_handled flag
             if will_save:
                 self.saving_handled = False
@@ -381,12 +380,12 @@ class MycroftSkillsManager(object):
             skill_state = None
             raise
         except MsmException as e:
-            LOG.exception('Failed to install skill ' + skill.name)
             skill_state.update(
                 installation='failed',
                 status='error',
                 failure_message=str(e)
             )
+            raise
         else:
             skill_state.update(
                 installed=time.time(),
@@ -396,6 +395,7 @@ class MycroftSkillsManager(object):
             )
         finally:
             # Store the entry in the list
+            print('STORING STATE!')
             if skill_state is not None:
                 self.device_skill_state['skills'].append(skill_state)
                 self._invalidate_skills_cache()

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Mycroft AI, Inc.
 #
 # This file is part of Mycroft Skills Manager
-# (see https://github.com/MatthewScholefield/mycroft-light).
+# (see https://github.com/MycroftAI/mycroft-skills-manager).
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -280,7 +280,7 @@ class SkillEntry(object):
 
     def run_pip(self, constraints=None):
         if not self.dependent_python_packages:
-            return
+            return False
 
         # Use constraints to limit the installed versions
         if constraints and not exists(constraints):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+requests
 GitPython
 fasteners
 lazy

--- a/tests/test_mycroft_skills_manager.py
+++ b/tests/test_mycroft_skills_manager.py
@@ -288,8 +288,9 @@ class TestMycroftSkillsManager(TestCase):
         skill_to_install.is_beta = False
         skill_to_install.install = Mock(side_effect=MsmException('RED ALERT!'))
         with patch('msm.mycroft_skills_manager.isinstance') as isinstance_mock:
-            isinstance_mock.return_value = True
-            self.msm.install(skill_to_install, origin='cli')
+            with self.assertRaises(MsmException):
+                isinstance_mock.return_value = True
+                self.msm.install(skill_to_install, origin='cli')
 
         with open(self.skills_json_path) as skills_json:
             device_skill_state = json.load(skills_json)

--- a/tests/test_mycroft_skills_manager.py
+++ b/tests/test_mycroft_skills_manager.py
@@ -21,16 +21,16 @@
 # under the License.
 import json
 import os
+from os.path import dirname, join
 import tempfile
 from pathlib import Path
 from shutil import copyfile, rmtree
 from unittest import TestCase
+
 from unittest.mock import call, Mock, patch
 
-import pytest
-
 from msm import MycroftSkillsManager, AlreadyInstalled, AlreadyRemoved
-from msm.exceptions import SkillNotFound, MultipleSkillMatches, MsmException
+from msm.exceptions import MsmException
 from msm.skill_state import device_skill_state_hash
 
 
@@ -44,7 +44,8 @@ class TestMycroftSkillsManager(TestCase):
         self._mock_skills_json_path()
         self._mock_skill_entry()
         self._mock_skill_repo()
-        copyfile('skills_test.json', str(self.skills_json_path))
+        copyfile(join(dirname(__file__), 'skills_test.json'),
+                 str(self.skills_json_path))
         self.msm = MycroftSkillsManager(
             platform='default',
             skills_dir=str(self.temp_dir.joinpath('skills')),
@@ -162,8 +163,10 @@ class TestMycroftSkillsManager(TestCase):
         self.assertTrue(self.skills_json_path.exists())
         with open(self.skills_json_path) as skills_json:
             device_skill_state = json.load(skills_json)
-        self.assertListEqual(initial_state, state['skills'])
-        self.assertListEqual(initial_state, device_skill_state['skills'])
+        self.assertListEqual(sorted(initial_state, key=lambda x: x['name']),
+            sorted(device_skill_state['skills'], key=lambda x:x['name']))
+        self.assertListEqual(sorted(initial_state, key=lambda x: x['name']),
+            sorted(device_skill_state['skills'], key=lambda x: x['name']))
         self.assertListEqual([], state['blacklist'])
         self.assertListEqual([], device_skill_state['blacklist'])
         self.assertEqual(2, state['version'])

--- a/tests/test_mycroft_skills_manager.py
+++ b/tests/test_mycroft_skills_manager.py
@@ -358,7 +358,8 @@ class TestMycroftSkillsManager(TestCase):
         )
         with patch('msm.mycroft_skills_manager.isinstance') as isinstance_mock:
             isinstance_mock.return_value = True
-            self.msm.remove(skill_to_remove)
+            with self.assertRaises(AlreadyRemoved):
+                self.msm.remove(skill_to_remove)
 
         self.assertListEqual([call.remove()], skill_to_remove.method_calls)
         self.assertIsNotNone(self.msm._local_skills)


### PR DESCRIPTION
Install now raises an error again which is needed for the install skill and command line app to recognize the install as a failure.

Going through making sure the test case for the install was valid I ran across a bunch of issues making the tests fail

The following has been fixed
- the path for skills.json expected tests to be run from a certain place
- fix list check of json loaded lists
- `SkillEntry.run_pip()` now returns False when no dependencies exists.
- remove action now return error when skill is not found locally