### PR TITLE
Handle git:// urls more gracefully

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -130,7 +130,12 @@ class SkillEntry(object):
             self.name = self.meta_info['name']
         else:
             self.name = basename(path)
-        from_github = (url.rstrip("/").split("/")[-3] == 'github.com') if url else False
+
+        # TODO: Handle git:// urls as well
+        from_github = False
+        if url.startswith('https://'):
+            url_tokens = url.rstrip("/").split("/")
+            from_github = url_tokens[-3] == 'github.com' if url else False
         self.author = self.extract_author(url) if from_github else ''
         self.id = self.extract_repo_id(url) if from_github else self.name
         self.is_local = exists(path)

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -34,6 +34,17 @@ class TestSkillEntry(object):
             url='https://github.com/testuser/testrepo.git/'
         )
 
+
+    def test_https_init(self):
+        s = SkillEntry('test-name', 'test-path',
+                       url='https://github.com/testuser/testrepo.git/')
+        assert s.author == 'testuser'
+
+    def test_git_ssl_init(self):
+        s = SkillEntry('test-name', 'test-path',
+                       url='git@github.com:forslund/skill-cocktail.git')
+        assert s.author == ''
+
     def test_attach(self):
         """Attach a remote entry to a local entry"""
         remote = SkillEntry(


### PR DESCRIPTION
Will currently just set the author field to '' like a any non-github
url, handling git:// urls will be a todo

Adds a simple test case to make sure this works as expected and doesn't
throw any exceptions.