### PR TITLE
Handle PermissionsError when creating skills repo

### DIFF
--- a/msm/skill_repo.py
+++ b/msm/skill_repo.py
@@ -114,7 +114,7 @@ class SkillRepo(object):
     def update(self):
         try:
             self.__prepare_repo()
-        except GitError as e:
+        except (GitError, PermissionError) as e:
             LOG.warning('Could not prepare repo ({}), '
                         ' Creating temporary repo'.format(repr(e)))
             original_path = self.path


### PR DESCRIPTION
The skills repo folder defaults to /opt/mycroft, if the folder can't be created due to permissions it will error out. This handles it by using the temporary folder if accessing the default folder triggers a permission error.

Should fix #71