### PR TITLE
appstores #0

### DIFF
--- a/examples/appstores.py
+++ b/examples/appstores.py
@@ -1,0 +1,26 @@
+from msm.appstores import pling, mycroft_marketplace
+from msm import appstores
+from msm import MycroftSkillsManager
+
+msm = MycroftSkillsManager()
+
+
+print("Searching pling appstore for hivemind")
+for s in pling.search("hivemind", msm=msm):
+    print(s.name)  # pling appstore only
+
+print("Searching mycroft marketplace for jokes")
+for s in mycroft_marketplace.search("jokes", msm=msm):
+    print(s.name)  # mycroft appstore only
+
+print("Searching everywhere for node red")
+for s in appstores.search("node red", min_conf=0.4, msm=msm):
+    print(s.name)  # All appstores
+
+print("Listing pling appstore skills")
+for s in pling.list_skills(msm=msm):
+    print(s.name)
+
+print("Listing mycroft marketplace skills")
+for s in mycroft_marketplace.list_skills(msm=msm):
+    print(s.name)

--- a/msm/appstores/__init__.py
+++ b/msm/appstores/__init__.py
@@ -1,0 +1,8 @@
+from msm.appstores import pling, mycroft_marketplace
+
+
+def search(*args, **kwargs):
+    for skill in mycroft_marketplace.search(*args, **kwargs):
+        yield skill
+    for skill in pling.search(*args, **kwargs):
+        yield skill

--- a/msm/appstores/mycroft_marketplace.py
+++ b/msm/appstores/mycroft_marketplace.py
@@ -1,0 +1,14 @@
+from msm import MycroftSkillsManager
+
+
+def search(name, author=None, msm=None, min_conf=0.3):
+    for skill in list_skills(msm):
+        if skill.match(name, author) >= min_conf:
+            yield skill
+
+
+def list_skills(msm=None):
+    msm = msm or MycroftSkillsManager()
+    for skill in msm.list():
+        yield skill
+

--- a/msm/appstores/pling.py
+++ b/msm/appstores/pling.py
@@ -1,0 +1,63 @@
+import requests
+from msm import MycroftSkillsManager
+from msm.util import xml2dict
+from msm.skill_entry import SkillEntry
+import json
+
+
+def _parse_pling(skill, msm):
+
+    if isinstance(skill, str):
+        json_data = json.loads(skill)
+    else:
+        json_data = skill
+
+    # TODO is it a safe assumption downloadlink1 is always the skill.json ?
+    # this can be made smarter
+    url = json_data["downloadlink1"]
+    skill_json = requests.get(url).json()
+
+    # save useful data to skill.meta_info
+    skill_json["category"] = json_data['typename']
+    skill_json["created"] = json_data['created']
+    skill_json["modified"] = json_data['changed']
+    skill_json["description"] = json_data["description"]
+    skill_json["tags"] = json_data['tags'].split(",")
+    skill_json["author"] = json_data['personid']
+    skill_json["version"] = json_data["version"]
+
+    # appstore data
+    # TODO also provide this from mycroft appstore
+    skill_json["appstore"] = "pling.opendesktop"
+    skill_json["appurl"] = json_data["detailpage"]
+
+    return SkillEntry.from_json(skill_json, msm)
+
+
+def list_skills(msm=None):
+    msm = msm or MycroftSkillsManager()
+
+    url = "https://api.kde-look.org/ocs/v1/content/data"
+    params = {"categories": "608", "page": 0}
+    xml = requests.get(url, params=params).text
+
+    data = xml2dict(xml)
+    meta = data["ocs"]["meta"]
+    n_pages = int(meta["totalitems"]) // int(meta["itemsperpage"])
+
+    for skill in data["ocs"]["data"]["content"]:
+        yield _parse_pling(skill, msm)
+
+    for n in range(1, n_pages + 1):
+        params = {"categories": "608", "page": n}
+        xml = requests.get(url, params=params).text
+
+        for skill in xml2dict(xml)["ocs"]["data"]["content"]:
+            yield _parse_pling(skill, msm)
+
+
+def search(name, author=None, msm=None, min_conf=0.3):
+    msm = msm or MycroftSkillsManager()
+    for skill in list_skills(msm):
+        if skill.match(name, author) >= min_conf:
+            yield skill

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 GitPython
 fasteners
 lazy
+pyyaml
+pako

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 setup(
     name='msm',
     version='0.8.7',
-    packages=['msm'],
+    packages=['msm', 'msm.appstores'],
     install_requires=[
         'GitPython', 'fasteners', 'pyyaml', 'pako',
         'lazy'


### PR DESCRIPTION
This PR adds the concept of appstore to msm

Currently [Pling](https://apps.plasma-bigscreen.org/) and Mycroft Marketplace are implemented, all this is in a subpackage


```python
from msm.appstores import pling, mycroft_marketplace
from msm import appstores
from msm import MycroftSkillsManager

msm = MycroftSkillsManager()


print("Searching pling appstore for hivemind")
for s in pling.search("hivemind", msm=msm):
    print(s.name)  # pling appstore only

print("Searching mycroft marketplace for jokes")
for s in mycroft_marketplace.search("jokes", msm=msm):
    print(s.name)  # mycroft appstore only

print("Searching everywhere for node red")
for s in appstores.search("node red", min_conf=0.4, msm=msm):
    print(s.name)  # All appstores

print("Listing pling appstore skills")
for s in pling.list_skills(msm=msm):
    print(s.name)

print("Listing mycroft marketplace skills")
for s in mycroft_marketplace.list_skills(msm=msm):
    print(s.name)
```


Discussion :

msm can be made to automatically check both appstores, this would be backwards compatible and automatically extend the command line usage and installer skill 

this will avoid the skills submission guidelines and raises the question of what is a valid appstore, could i just spin up my own and host malware? feedback welcome on what is the correct next step