### PR TITLE
Fix issues with permissions

### DIFF
--- a/msm/skill_repo.py
+++ b/msm/skill_repo.py
@@ -23,6 +23,7 @@ from glob import glob
 from os import makedirs
 from os.path import exists, join, isdir, dirname, basename, normpath
 import json
+from tempfile import gettempdir
 
 from git import Repo
 from git.exc import GitCommandError, GitError
@@ -118,7 +119,7 @@ class SkillRepo(object):
             LOG.warning('Could not prepare repo ({}), '
                         ' Creating temporary repo'.format(repr(e)))
             original_path = self.path
-            self.path = '/tmp/.skills-repo'
+            self.path = join(gettempdir(), '.skills-repo')
             try:
                 with git_to_msm_exceptions():
                     self.__prepare_repo()

--- a/msm/util.py
+++ b/msm/util.py
@@ -22,8 +22,10 @@
 import time
 
 import git
-from os.path import exists
+from os.path import exists, join
 from os import chmod
+from tempfile import gettempdir
+
 from fasteners.process_lock import InterProcessLock
 
 
@@ -42,7 +44,7 @@ class Git(git.cmd.Git):
 
 class MsmProcessLock(InterProcessLock):
     def __init__(self):
-        lock_path = '/tmp/msm_lock'
+        lock_path = join(gettempdir(), 'msm_lock')
         if not exists(lock_path):
             lock_file = open(lock_path, '+w')
             lock_file.close()


### PR DESCRIPTION
This fixes a couple of issues with how things are handled when msm don't have the right to write to the disk in the standard locations.

- Respect the tmpdir set by the system
- Fix using the in memory representation of the skills-meta-data.json if the cache file can't be opened for writing