### PR TITLE
Migrate installed skills file to XDG Base Directory

### DIFF
--- a/msm/skill_state.py
+++ b/msm/skill_state.py
@@ -1,16 +1,24 @@
 """Functions related to manipulating the skills.json file."""
 import json
+import os
+import shutil
 from logging import getLogger
-from os.path import expanduser, isfile, dirname
+from os.path import isfile, dirname, join, expanduser
 from os import makedirs
+from xdg import BaseDirectory
 
 LOG = getLogger(__name__)
-SKILL_STATE_PATH = '~/.mycroft/skills.json'
+SKILL_STATE_PATH = join(BaseDirectory.save_data_path('mycroft'), 'skills.json')
+
+# Make sure we migrate the installed skills file from the old non-XDG location
+old_skill_state_path = expanduser('~/.mycroft/skills.json')
+if isfile(old_skill_state_path):
+    shutil.move(old_skill_state_path, SKILL_STATE_PATH)
 
 
 def load_device_skill_state() -> dict:
     """Contains info on how skills should be updated"""
-    skills_data_path = expanduser(SKILL_STATE_PATH)
+    skills_data_path = SKILL_STATE_PATH
     device_skill_state = {}
     if isfile(skills_data_path):
         try:
@@ -24,13 +32,13 @@ def load_device_skill_state() -> dict:
 
 def write_device_skill_state(data: dict):
     """Write the device skill state to disk."""
-    dir_path = dirname(expanduser(SKILL_STATE_PATH))
+    dir_path = dirname(SKILL_STATE_PATH)
     try:
         # create folder if it does not exist
         makedirs(dir_path)
     except Exception:
         pass
-    skill_state_path = expanduser(SKILL_STATE_PATH)
+    skill_state_path = SKILL_STATE_PATH
     with open(skill_state_path, 'w') as skill_state_file:
         json.dump(data, skill_state_file, indent=4, separators=(',', ':'))
 
@@ -47,7 +55,7 @@ def get_skill_state(name, device_skill_state) -> dict:
 
 def initialize_skill_state(name, origin, beta, skill_gid) -> dict:
     """Create a new skill entry
-    
+
     Arguments:
         name: skill name
         origin: the source of the installation

--- a/msm/skill_state.py
+++ b/msm/skill_state.py
@@ -8,17 +8,26 @@ from os import makedirs
 from xdg import BaseDirectory
 
 LOG = getLogger(__name__)
-SKILL_STATE_PATH = join(BaseDirectory.save_data_path('mycroft'), 'skills.json')
+
+
+def get_state_path():
+    """Get complete path for skill state file.
+
+    Returns:
+        (str) path to skills.json
+    """
+    return join(BaseDirectory.save_data_path('mycroft'), 'skills.json')
+
 
 # Make sure we migrate the installed skills file from the old non-XDG location
 old_skill_state_path = expanduser('~/.mycroft/skills.json')
 if isfile(old_skill_state_path):
-    shutil.move(old_skill_state_path, SKILL_STATE_PATH)
+    shutil.move(old_skill_state_path, get_state_path())
 
 
 def load_device_skill_state() -> dict:
     """Contains info on how skills should be updated"""
-    skills_data_path = SKILL_STATE_PATH
+    skills_data_path = get_state_path()
     device_skill_state = {}
     if isfile(skills_data_path):
         try:
@@ -32,13 +41,13 @@ def load_device_skill_state() -> dict:
 
 def write_device_skill_state(data: dict):
     """Write the device skill state to disk."""
-    dir_path = dirname(SKILL_STATE_PATH)
+    dir_path = dirname(get_state_path())
     try:
         # create folder if it does not exist
         makedirs(dir_path)
     except Exception:
         pass
-    skill_state_path = SKILL_STATE_PATH
+    skill_state_path = get_state_path()
     with open(skill_state_path, 'w') as skill_state_file:
         json.dump(data, skill_state_file, indent=4, separators=(',', ':'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 GitPython
 fasteners
 lazy
+pyxdg

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=['msm'],
     install_requires=[
         'GitPython', 'fasteners', 'pyyaml', 'pako',
-        'lazy'
+        'lazy', 'pyxdg'
     ],
     python_requires='>=3.5',
     url='https://github.com/MycroftAI/mycroft-skills-manager',

--- a/tests/test_mycroft_skills_manager.py
+++ b/tests/test_mycroft_skills_manager.py
@@ -67,9 +67,9 @@ class TestMycroftSkillsManager(TestCase):
         self.log_mock = log_patch.start()
 
     def _mock_skills_json_path(self):
-        expanduser_patch = patch('msm.skill_state.expanduser')
-        self.addCleanup(expanduser_patch.stop)
-        self.skills_json_path_mock = expanduser_patch.start()
+        savedatapath_patch = patch('msm.skill_state.BaseDirectory.save_data_path')
+        self.addCleanup(savedatapath_patch.stop)
+        self.skills_json_path_mock = savedatapath_patch.start()
         self.skills_json_path_mock.return_value = str(
             self.temp_dir.joinpath('skills.json')
         )

--- a/tests/test_mycroft_skills_manager.py
+++ b/tests/test_mycroft_skills_manager.py
@@ -67,12 +67,13 @@ class TestMycroftSkillsManager(TestCase):
         self.log_mock = log_patch.start()
 
     def _mock_skills_json_path(self):
-        savedatapath_patch = patch('msm.skill_state.BaseDirectory.save_data_path')
-        self.addCleanup(savedatapath_patch.stop)
+        savedatapath_patch = patch('msm.skill_state.get_state_path')
         self.skills_json_path_mock = savedatapath_patch.start()
         self.skills_json_path_mock.return_value = str(
             self.temp_dir.joinpath('skills.json')
         )
+
+        self.addCleanup(savedatapath_patch.stop)
 
     def _mock_skill_entry(self):
         skill_entry_patch = patch(


### PR DESCRIPTION
#### Description
Combined with https://github.com/MycroftAI/mycroft-core/pull/2578
`~/.mycroft/skills.json` is now migrated to follow the XDG Base Directory
specification.

This means it'll be installed to `$XDG_DATA_HOME/mycroft/skills.json`,
or `$HOME/.local/share/mycroft/skills.json` if `$XDG_DATA_HOME` is unset

The file is migrated from the old location if it still exists there

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Run MSM at least once without this PR and without https://github.com/MycroftAI/mycroft-core/pull/2578 and make sure `~/.mycroft/skills.json` exists.

Then run MyCroft and MSM with https://github.com/MycroftAI/mycroft-core/pull/2578 and this PR, and verify that `~/.mycroft/skills.json` has been moved to `~/.local/share/mycroft/skills.json` (assuming you haven't changed `$XDG_DATA_HOME`) and that everything still works correctly as before.

#### Documentation
No documentation updates are needed
