### PR TITLE
Use no-confirm flag on Pako

### DIFF
--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -67,7 +67,8 @@ def _perform_pako_install(packages, system_packages=None):
     """
     try:
         manager = PakoManager()
-        success = manager.install(packages, overrides=system_packages)
+        success = manager.install(
+            packages, overrides=system_packages, flags=['no-confirm'])
     except RuntimeError as e:
         LOG.warning('Failed to launch package manager: {}'.format(e))
         success = False

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 GitPython
 fasteners
 lazy
-pako
+pako>=0.3.1,<0.4.0
 pyxdg
 pyyaml
 requests


### PR DESCRIPTION
#### Description
This uses the new `no-confirm` flag in Pako to automatically accept package manager confirmations. 

Previously some Skill installations would fail by voice if the package manager needed a response to a prompt.

#### Type of PR
- [x] Feature implementation

#### Testing
Install pako==0.3.1
Attempt to install a Skill like Pandora