### PR TITLE
Replace multiprocessing with concurrent.futures

### DIFF
--- a/msm/mycroft_skills_manager.py
+++ b/msm/mycroft_skills_manager.py
@@ -23,12 +23,12 @@
 
 MSM can be used on the command line but is also used by Mycroft core daemons.
 """
+from concurrent.futures import ThreadPoolExecutor
 import time
 import logging
 import shutil
 from functools import wraps
 from glob import glob
-from multiprocessing.pool import ThreadPool
 from os import path
 from typing import Dict, List
 
@@ -487,8 +487,8 @@ class MycroftSkillsManager(object):
                     func.__name__, skill.name
                 ))
 
-        with ThreadPool(max_threads) as tp:
-            return tp.map(run_item, skills)
+        with ThreadPoolExecutor(max_threads) as executor:
+            return executor.map(run_item, skills)
 
     @save_device_skill_state
     def install_defaults(self):


### PR DESCRIPTION
#### Description
This uses the `ThreadPoolExecutor` from `concurrent.futures` instead of multiprocessings threadpool since the threadpool in multiprocessing can't safely be used in a multithreaded context in Python 3.9+. See https://github.com/MycroftAI/mycroft-core/issues/2799

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Ensure unittests still works and for manual testing `msm default` will utilize the ThreadPoolExecutor

Run together with https://github.com/MycroftAI/padatious/pull/34 on python 3.9 and ensure there are no errors training padatious or updating skills.