### PR TITLE
update the default branch of the mycroft-skills repository

### DIFF
--- a/msm/skill_repo.py
+++ b/msm/skill_repo.py
@@ -116,7 +116,7 @@ class SkillRepo(object):
         self.path = join(BaseDirectory.save_data_path('mycroft'),
                          'skills-repo')
         self.url = url or "https://github.com/MycroftAI/mycroft-skills"
-        self.branch = branch or "20.08"
+        self.branch = branch or "21.02"
         self.repo_info = {}
 
     @cached_property(ttl=FIVE_MINUTES)


### PR DESCRIPTION
#### Description
Fix a bug that defaults the skill branch to 20.08.  Latest is 21.02

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
More recent versions of skills are installed by MSM

#### Documentation
N/A
