### PR TITLE
Use git.Repo() to determine remote url

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        python setup.py install
+        python -m pip install -r requirements/tests.txt
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/msm/skill_entry.py
+++ b/msm/skill_entry.py
@@ -562,7 +562,7 @@ class SkillEntry(object):
                 'Attempting to retrieve the remote origin URL config for '
                 'skill in path ' + path
             )
-            return Git(path).config('remote.origin.url')
+            return Repo(path).remote('origin').url
         except GitError:
             return ''
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,1 +1,2 @@
 pytest
+flake8


### PR DESCRIPTION
#### Description
In newer GitPython the Git(path).config() seems to fall back to info
contained in the current directory leading to a possible mixup of origin
URLs. (as illustrated in the test case test_from_folder())

This replaces the check with a check using Repo.remote() to find the
remote for a repo at a location.

Also fixes an issue where the install on the github-action runner doesn't respect the python version limitations of the installed package.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.

- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [x] Test improvements

#### Testing
Ensure that the unittests on github passes.
